### PR TITLE
add size(height, width, depth) info to Annotation

### DIFF
--- a/generatePascalXML.m
+++ b/generatePascalXML.m
@@ -1,7 +1,9 @@
-function generatePascalXML(imgName, bboxList, targetName)
+function generatePascalXML(imgDir, imgName, bboxList, targetName)
 %GENERATEPASCALXML a Pascal VOC syntax annotation generator
 %   GENERATEPASCALXML(IMGNAME, BBOXLIST, TARGETNAME) generates
 %   Pascal VOC compatible XML annotations where
+%
+%   `imgDir` is the path of img to get metadata
 %
 %   `imgName` is the name of the image file (to be stored in the
 %       xml annotation.
@@ -90,6 +92,27 @@ sourceElem.appendChild(annotationElem);
 elem = docNode.createElement('owner');
 docRootNode.appendChild(elem);
 
+% size element
+sizeElem = docNode.createElement('size');
+% get metadata from image
+immeta = imfinfo(imgDir);
+% store width
+elem = docNode.createElement('width');
+elem.appendChild...
+    (docNode.createTextNode(sprintf('%s', immeta.Width)));
+sizeElem.appendChild(elem);
+% store height
+elem = docNode.createElement('height');
+elem.appendChild...
+    (docNode.createTextNode(sprintf('%s', immeta.Height)));
+sizeElem.appendChild(elem);
+% store depth, assume 3
+elem = docNode.createElement('depth');
+elem.appendChild...
+    (docNode.createTextNode(sprintf('%s', 3)));
+sizeElem.appendChild(elem);
+docRootNode.appendChild(sizeElem);
+
 % name element
 ownerNameElem = docNode.createElement('name');
 ownerNameElem.appendChild...
@@ -141,6 +164,7 @@ for i = 1:size(bboxList, 1)
     elem.appendChild...
         (docNode.createTextNode(sprintf('%d', round(ymax))));
     bboxElem.appendChild(elem);
+    clc
 end
 
 xmlwrite(targetName, docNode);

--- a/wider2pascal.m
+++ b/wider2pascal.m
@@ -67,11 +67,13 @@ for i = 1: numel(partitionData.event_list)
     % loop over the images associated with each event
     for j = 1:numel(files)
         imgName = strcat(files{j}, '.jpg');
+        imgDir = fullfile(widerRootDir, sprintf('WIDER_%s', partition), 'images', partitionData.event_list{i}, strcat(files{j}, '.jpg'));
         annotationFileName = fullfile(annotationsDir, ...
             strcat(files{j}, '.xml'));
-        generatePascalXML(imgName, bboxList{j}, annotationFileName);
+        generatePascalXML(imgDir, imgName, bboxList{j}, annotationFileName);
     end
 end
+clc
 
 %-------------------------------------------------------------------
 function copyImages(widerRootDir, jpegImagesDir, partition)
@@ -106,6 +108,7 @@ for i = 1: numel(partitionData.event_list)
         copyfile(imgPaths{j}, jpegImagesDir);
     end
 end
+clc
 
 %-------------------------------------------------------------------
 function generateImageSets(widerRootDir, imageSetsDir, partition)
@@ -132,3 +135,4 @@ for i = 1:numel(files)
     fprintf(fileID, '%s\n', files{i});
 end
 fclose(fileID);
+clc


### PR DESCRIPTION
Hi, I used your code to convert wider face to pascal format, but when I use convert_box_data in caffe, it reminds me that there's no size info in the xml file. So I add a few codes to refine it and also add some clc code to clean the echo.